### PR TITLE
Missing line after setting tenant based on URL

### DIFF
--- a/source/shared-database-isolated-schema.rst
+++ b/source/shared-database-isolated-schema.rst
@@ -138,6 +138,7 @@ Now we can separate the tenants in the views using these functions.
 
         def get_queryset(self):
             set_tenant_schema_for_request(self.request)
+            tenant = tenant_from_request(self.request)
             return super().get_queryset().filter(tenant=tenant)
 
         def destroy(self, request, *args, **kwargs):


### PR DESCRIPTION
Missing line where tenant variable was not set with respect to the current tenant