### PR TITLE
typo:fix-litter-filter

### DIFF
--- a/source/shared-database-isolated-schema.rst
+++ b/source/shared-database-isolated-schema.rst
@@ -21,7 +21,7 @@ Because each tenant's data stays in the same schema, there is no way to limit ac
 Tenant isolation code is intermixed with app code
 ==================================================
 
-You need to litter your code with :code:`.filter(tenant=tenant)` every time you access the database. For example in your :code:`ViewSet` you would be doing this:
+You need to filter your code with :code:`.filter(tenant=tenant)` every time you access the database. For example in your :code:`ViewSet` you would be doing this:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixed the Typo litter to **filter** in **"Tenant isolation code is intermixed with app code"** section of **shared-database-isolated-schema**

Resolves #48 