### PR TITLE
fix:typo in get_tenants_map function

### DIFF
--- a/isolated-db/tenants/utils.py
+++ b/isolated-db/tenants/utils.py
@@ -13,4 +13,4 @@ def tenant_db_from_request(request):
 
 
 def get_tenants_map():
-    return {"thor.polls.local": "thor", "poter.polls.local": "potter"}
+    return {"thor.polls.local": "thor", "potter.polls.local": "potter"}


### PR DESCRIPTION
A typo fix
File Path: isolated-db/tenants/utils.py
Line: 16
has been fixed:
```python
def get_tenants_map():
    return {"thor.polls.local": "thor", "potter.polls.local": "potter"}
```